### PR TITLE
ForegroundService not allowed crash happening in background for android 14

### DIFF
--- a/library/src/main/java/com/liulishuo/filedownloader/services/FileDownloadService.java
+++ b/library/src/main/java/com/liulishuo/filedownloader/services/FileDownloadService.java
@@ -120,6 +120,7 @@ public class FileDownloadService extends Service {
         } catch (Exception e) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && e instanceof ForegroundServiceStartNotAllowedException) {
                 FileDownloadLog.d(this, "Failed to start service because app is not in valid state to start a service with exception: %s", e.getLocalizedMessage());
+                stopSelf();
             }
         }
     }


### PR DESCRIPTION
What problem do you get?
Fatal Exception: java.lang.RuntimeException
Unable to start service com.liulishuo.filedownloader.services.FileDownloadService$SharedMainProcessService@4f09cbf with Intent { cmp=../com.liulishuo.filedownloader.services.FileDownloadService$SharedMainProcessService (has extras) }: android.app.ForegroundServiceStartNotAllowedException: Service.startForeground() not allowed due to mAllowStartForeground false: service ../com.liulishuo.filedownloader.services.FileDownloadService$SharedMainProcessService

Crash is not reproducible, happening 100% background and 100% in Android 14.

Which version of FileDownloader are you using when you produce such problem?
Tried both 1.7.9 and 1.7.10. 
Getting crashes in both.
How to reproduce such problem?
Only seeing it in Crashalytics and it is not reproducible locally
Related topic:
https://issuetracker.google.com/issues/307329994

Closes #22.